### PR TITLE
Revert hero heading color change

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -47,7 +47,7 @@
   font-size: var(--text-5xl);
   font-weight: var(--font-weight-extralight);
   letter-spacing: var(--letter-spacing-tighter);
-  color: red;
+  color: var(--text-primary);
   line-height: var(--line-height-tight);
   margin-bottom: var(--space-6);
   max-width: none;


### PR DESCRIPTION
## Summary
- revert the hero heading color back to the theme primary text variable
- remove the previous hard-coded red text color to restore intended styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693dcaf572688330b25513a1736f8e73)